### PR TITLE
#10670: Add AGENTS.md for AI coding assistant guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,11 +39,12 @@ own (CDK synth/deploy, `terraform plan`/`apply`, or `gcloud builds submit`)
 
 ## Configuration
 
-Configuration is per-cloud (env files, `.tfvars`, Helm values). Do not treat
-one cloud folder's config file as a template for another — the variable
-names and required values differ (e.g. AWS uses `aws/.env` with an ACM
-certificate ARN; Azure and GCP use `terraform plan -var=...` flags plus
-their own `deployments/*.env` files).
+Configuration is per-cloud. AWS uses `aws/.env`; Azure uses Terraform
+variables and deployment configuration; GCP uses Terraform tfvars
+(`terraform-variables/dev/pre-config/pre-config.tfvars`), Cloud Build
+substitutions, and deployment configuration. Do not treat one cloud
+folder's configuration as a template for another. Follow its own guide
+(`aws/AGENTS.md`, `azure/AGENTS.md`, `gcp/AGENTS.md`).
 
 ## Project Structure Notes
 
@@ -57,10 +58,14 @@ inji-infra-cloud/
 
 A few things worth knowing before you touch files:
 
-- `aws/helm/**`, and the vendored chart trees under `azure/` and `gcp/`
-  `deployments/configs`, include third-party/upstream Helm chart source
-  (e.g. Bitnami `common` library templates). Treat these as vendored —
-  don't "clean up" or restyle code you didn't author there.
+- `aws/helm/**` contains vendored chart source, including third-party
+  Bitnami `common` templates. Treat that chart tree as vendored — don't
+  "clean up" or restyle code you didn't author there.
+- `azure/deployments/configs/` and `gcp/deployments/configs/` are
+  **not** vendored chart trees — they hold this repo's own service
+  configuration (Helm `values.yaml`, ingress manifests, `.env` files).
+  Edit them freely when the task calls for a deployment configuration
+  change.
 - `aws/inji-certify-aws-automation/` is a **plain subdirectory** with its
   own `package.json`/`cdk.json`, not a git submodule — it is a second,
   separate CDK app nested inside `aws/`.
@@ -72,8 +77,10 @@ A few things worth knowing before you touch files:
 1. Work inside exactly one cloud folder (`aws/`, `azure/`, or `gcp/`) at a
    time — cross-cloud changes in one PR make review harder and are not the
    norm in this repo's history.
-2. Read that folder's README and AGENTS.md fully before changing
-   Terraform/CDK code — these scripts provision real cloud resources.
+2. Read that folder's README and AGENTS.md fully before changing any
+   file inside it — Terraform/CDK code, Helm charts, shell scripts,
+   Cloud Build YAML, values, and documentation alike support workflows
+   that provision real cloud resources.
 3. There is no CI in this repository. Validate your own changes locally
    (`terraform plan`, `cdk synth`, `helm template`, etc. as applicable)
    before opening a PR — nothing else will catch mistakes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,142 @@
+# AGENTS.md
+
+## Repository Overview
+
+`inji-infra-cloud` holds one-click deployment automation for the INJI stack
+(inji-certify, mimoto, inji-web, inji-verify, plus eSignet and Sunbird RC
+registry components) across three public clouds. There is no shared code
+between the clouds — each top-level folder is a self-contained deployment
+project with its own tooling, its own README, and its own release cadence:
+
+| Folder | Cloud | What it provisions with | Guide |
+|--------|-------|--------------------------|-------|
+| `aws/` | Amazon Web Services | AWS CDK (TypeScript) + Helm | [aws/AGENTS.md](aws/AGENTS.md) |
+| `azure/` | Microsoft Azure | Terraform + Helm + shell scripts | [azure/AGENTS.md](azure/AGENTS.md) |
+| `gcp/` | Google Cloud Platform | Terraform + Cloud Build + Helm | [gcp/AGENTS.md](gcp/AGENTS.md) |
+
+Because the three folders share no build system, no CI, and no code, this
+root file only orients you — read the sub-guide for the folder you are
+actually changing before doing anything there.
+
+## Technology Stack
+
+- No language or framework is shared repo-wide. Each cloud folder uses a
+  different stack — see its own AGENTS.md.
+- Common thread across all three: Kubernetes (EKS / AKS / GKE) as the
+  runtime target, and Helm charts to deploy the INJI/eSignet/Sunbird RC
+  services onto it.
+- There is no root `package.json`, no root build file, and no
+  `.github/workflows` CI pipeline in this repository (verified against the
+  `develop` branch) — nothing here is automatically built, linted, or
+  deployed by CI. Everything is run by hand from a workstation or bastion
+  host, following the steps in each folder's README.
+
+## Build & Test Commands
+
+There is no repo-wide build or test command. Each cloud folder documents its
+own (CDK synth/deploy, `terraform plan`/`apply`, or `gcloud builds submit`)
+— see the sub-guide.
+
+## Configuration
+
+Configuration is per-cloud (env files, `.tfvars`, Helm values). Do not treat
+one cloud folder's config file as a template for another — the variable
+names and required values differ (e.g. AWS uses `aws/.env` with an ACM
+certificate ARN; Azure and GCP use `terraform plan -var=...` flags plus
+their own `deployments/*.env` files).
+
+## Project Structure Notes
+
+```text
+inji-infra-cloud/
+├── aws/     - AWS CDK app + vendored Helm charts + inji-certify-aws-automation sub-app
+├── azure/   - Terraform modules + deployment shell scripts + Helm values
+├── gcp/     - Terraform + Cloud Build YAML wrappers + Helm values
+└── .gitignore
+```
+
+A few things worth knowing before you touch files:
+
+- `aws/helm/**`, and the vendored chart trees under `azure/` and `gcp/`
+  `deployments/configs`, include third-party/upstream Helm chart source
+  (e.g. Bitnami `common` library templates). Treat these as vendored —
+  don't "clean up" or restyle code you didn't author there.
+- `aws/inji-certify-aws-automation/` is a **plain subdirectory** with its
+  own `package.json`/`cdk.json`, not a git submodule — it is a second,
+  separate CDK app nested inside `aws/`.
+- There is no root README in this repository; each cloud folder's README is
+  the actual source of truth for that folder.
+
+## Development Workflow
+
+1. Work inside exactly one cloud folder (`aws/`, `azure/`, or `gcp/`) at a
+   time — cross-cloud changes in one PR make review harder and are not the
+   norm in this repo's history.
+2. Read that folder's README and AGENTS.md fully before changing
+   Terraform/CDK code — these scripts provision real cloud resources.
+3. There is no CI in this repository. Validate your own changes locally
+   (`terraform plan`, `cdk synth`, `helm template`, etc. as applicable)
+   before opening a PR — nothing else will catch mistakes.
+4. Keep commits scoped to the folder you changed.
+
+## Pull Request Guidelines
+
+- Target the `develop` branch.
+- Describe which cloud (aws/azure/gcp) and which stage (infra provisioning
+  vs. service/Helm deployment) your change affects.
+- If a change affects deployed resource shapes (VPC CIDRs, cluster sizing,
+  IAM/service-account roles, firewall rules), say so explicitly in the PR
+  description — these are infrastructure changes with real cost and access
+  implications.
+- Do not include real cloud account IDs, subscription IDs, project IDs,
+  certificate ARNs, or credentials in PR descriptions or screenshots.
+
+## Repository-Specific Considerations
+
+- **This is infrastructure-provisioning code.** `terraform apply`,
+  `terraform destroy`, `cdk deploy`, and the `gcloud builds submit
+  .../destroy-script.yaml` commands documented in the sub-guides create and
+  delete real cloud resources (VPCs, Kubernetes clusters, databases, load
+  balancers, service accounts). Never run an apply/deploy/destroy command
+  as a side effect of exploring the repo — only run one when the user has
+  explicitly asked for that action, and confirm the target cloud
+  account/project/subscription first.
+- **Sample secret-shaped files already exist in this repo** — e.g.
+  `gcp/deployments/secrets/key.jwk` (an RSA JWK) and various
+  `deployments/*.env` / `.tfvars` files across `azure/` and `gcp/` carry
+  demo values (test domains, demo project/resource names). Do not assume
+  these are safe patterns to copy with real values, and never add a real
+  private key, password, connection string, or cloud credential to any
+  tracked file — pass secrets via environment variables, `-var` flags, or
+  a cloud secret manager instead, matching what each folder's README
+  already documents.
+- The three folders were contributed independently (AWS first, then Azure
+  and GCP), so naming conventions and folder layouts differ between them
+  even though they deploy the same INJI services — do not assume symmetry.
+
+## Agent rules
+
+### Do
+
+1. Read the relevant cloud folder's `AGENTS.md` and `README.md` before
+   editing anything inside it.
+2. Keep changes scoped to a single cloud folder per PR.
+3. Treat vendored Helm chart trees (Bitnami `common` templates, etc.) as
+   read-only unless the task specifically asks you to change them.
+4. Call out any change to provisioned resource shape (sizing, networking,
+   IAM) explicitly in the PR description.
+5. Use environment variables, `-var` flags, or a secret manager for any
+   credential — never hardcode one into a tracked file.
+
+### Do not
+
+1. Do not run `terraform apply`, `terraform destroy`, `cdk deploy`, or any
+   `gcloud builds submit .../destroy-script.yaml` command unless the user
+   has explicitly asked you to provision or tear down infrastructure.
+2. Do not copy a real cloud account ID, subscription ID, project ID,
+   certificate ARN, private key, or credential into any file, commit, or
+   PR description.
+3. Do not assume there is a CI pipeline that will validate your change —
+   this repository has none.
+4. Do not mix changes across `aws/`, `azure/`, and `gcp/` in a single PR
+   unless the task explicitly requires it.

--- a/aws/AGENTS.md
+++ b/aws/AGENTS.md
@@ -1,0 +1,141 @@
+# AGENTS.md
+
+Scope: this file covers the `aws/` folder only. See the [root
+AGENTS.md](../AGENTS.md) for how this folder relates to `azure/` and
+`gcp/`.
+
+## Repository Overview
+
+One-click deployment of the INJI stack (mimoto, inji-web, inji-verify) onto
+AWS. It uses **AWS CDK (TypeScript)** to provision infrastructure (VPC, EKS
+cluster) and **Helm** (invoked from within the CDK stacks, or standalone)
+to deploy the application services. A companion CDK app,
+`inji-certify-aws-automation/`, provisions the eSignet/Sunbird RC/certify
+side of the stack separately (see its own README under
+`inji-certify-aws-automation/documentation/`).
+
+Two supported deployment modes, per `aws/README.md`:
+
+- **Mode 1**: CDK provisions AWS infra and installs the Helm chart in one
+  pass (`documentation/01-Deployment-CDK-INJI.md`).
+- **Mode 2**: Helm chart installed directly against existing AWS
+  infrastructure (RDS, EKS) without running CDK
+  (`documentation/02-Deployment-Helm-INJI.md`).
+
+## Technology Stack
+
+- AWS CDK v2 (`aws-cdk-lib` 2.138.0, `aws-cdk` CLI 2.138.0)
+- TypeScript ~5.4.5, compiled with `tsc`
+- Jest + ts-jest for tests
+- Helm charts (vendored under `helm/`) for in-cluster deployment
+- Node.js/npm (version not pinned in `package.json` — use whatever the CDK
+  v2.138 toolchain supports)
+
+## Build & Test Commands
+
+Run these from inside `aws/`:
+
+```bash
+npm install
+npm run build      # tsc compile
+npm test           # jest, runs test/inji-aws-automation.test.ts
+npx cdk synth       # render the CloudFormation template without deploying
+npx cdk diff        # compare against the deployed stack
+npx cdk deploy       # provision AWS resources — see caution below
+```
+
+The same commands apply inside `inji-certify-aws-automation/`, which is a
+separate CDK app with its own `package.json`.
+
+## Configuration
+
+- `aws/.env` holds the mandatory inputs read by the CDK app: AWS
+  `ACCOUNT`, `REGION`, `CIDR`, `EKS_CLUSTER_NAME`, `DOMAIN`,
+  `CERTIFICATE_ARN` (an ACM certificate ARN), `LOADBALANCER_NAME`,
+  `S3_BUCKET_NAME`. The account ID and certificate ARN checked into this
+  file on `develop` are example/demo values — replace them with your own
+  before deploying, and never commit real ones back.
+- `aws/inji-certify-aws-automation/.env` is a separate env file for that
+  sub-app; check its own README before editing.
+- `cdk.json` fixes the CDK app entrypoint and a long list of CDK feature
+  flags (`context`) — do not remove entries from `context` without
+  understanding which CDK behavior each flag controls, since several
+  affect IAM policy generation and default removal policies.
+
+## Project Structure Notes
+
+```text
+aws/
+├── bin/inji-aws-automation.ts   - CDK app entrypoint
+├── lib/                          - CDK stack definitions
+│   ├── vpc-stack.ts
+│   ├── eks-ec2-stack.ts
+│   ├── mimoto-helm-stack.ts
+│   ├── inji-web-helm-stack.ts
+│   ├── inji-verify-helm-stack.ts
+│   └── config.ts
+├── test/                         - Jest tests
+├── helm/                         - Vendored Helm charts (inji-esignet, inji-sunbird-rc-charts)
+├── packages/                     - additional packaged assets
+├── documentation/                - step-by-step deployment guides + images
+└── inji-certify-aws-automation/  - separate CDK app for certify/eSignet/Sunbird RC infra
+```
+
+`helm/` contains full vendored chart trees (including third-party Bitnami
+`common` library templates under `charts/common/`) — these are dependency
+code, not something to hand-edit as part of a feature change.
+
+## Development Workflow
+
+1. Install dependencies and run `npm run build` before touching stacks —
+   catches TypeScript errors early.
+2. Use `npx cdk synth` / `npx cdk diff` to check the effect of a stack
+   change before running `npx cdk deploy`.
+3. Run `npm test` for any change to `lib/*.ts`.
+4. Follow whichever of the two deployment-mode docs
+   (`documentation/01-*.md` or `documentation/02-*.md`) matches the change
+   you're making — they describe different entry points into the same
+   Helm charts.
+
+## Pull Request Guidelines
+
+- State which CDK stack(s) (`vpc-stack`, `eks-ec2-stack`,
+  `mimoto-helm-stack`, `inji-web-helm-stack`, `inji-verify-helm-stack`) are
+  affected.
+- If a change alters IAM policies, security groups, or the VPC CIDR,
+  mention that explicitly — these directly affect deployed AWS
+  permissions/networking.
+- Do not include a real AWS account ID, ACM certificate ARN, or S3 bucket
+  name from a live deployment in the PR description.
+
+## Repository-Specific Considerations
+
+- `npx cdk deploy` and `npx cdk destroy` provision/tear down real AWS
+  resources against whatever `ACCOUNT`/`REGION` is set in `.env` or your
+  AWS CLI profile. Never run them without the user's explicit request, and
+  confirm the target account first.
+- `inji-certify-aws-automation/` is a nested, independent CDK app (its own
+  `.env`, `cdk.json`, `package.json`) — changes to `aws/` top-level stacks
+  do not automatically apply to it and vice versa.
+
+## Agent rules
+
+### Do
+
+1. Run `npm run build` and `npm test` before proposing a change to
+   `lib/*.ts`.
+2. Use `npx cdk diff` to review the effect of a stack change before
+   suggesting `cdk deploy`.
+3. Treat `helm/**` vendored chart trees as read-only unless the task
+   specifically requires editing them.
+4. Point out IAM, security-group, or CIDR changes explicitly when they
+   occur.
+
+### Do not
+
+1. Do not run `npx cdk deploy` or `npx cdk destroy` unless the user has
+   explicitly asked to provision or tear down AWS infrastructure.
+2. Do not put a real AWS account ID, ACM certificate ARN, or other live
+   value into `.env`, a commit, or a PR description.
+3. Do not edit vendored chart files under `helm/**/charts/common/` as
+   part of an unrelated feature change.

--- a/azure/AGENTS.md
+++ b/azure/AGENTS.md
@@ -1,0 +1,162 @@
+# AGENTS.md
+
+Scope: this file covers the `azure/` folder only. See the [root
+AGENTS.md](../AGENTS.md) for how this folder relates to `aws/` and `gcp/`.
+
+## Repository Overview
+
+One-click deployment of the INJI stack (inji-certify, mimoto, inji-web,
+inji-verify) plus eSignet and Sunbird RC (registry) onto Azure. Deployment
+has two stages, per `azure/README.md`:
+
+- **Infrastructure**: Terraform provisions the AKS cluster, networking,
+  bastion host, Postgres, and identity resources.
+- **Service deployment**: shell scripts (run from the bastion host) invoke
+  Helm to install the INJI/eSignet/RC charts, using config under
+  `deployments/`.
+
+## Technology Stack
+
+- Terraform for Azure (azurerm provider, modules under
+  `terraform-scripts/infra/modules/`)
+- Helm charts, driven by shell scripts (`inji_deploy.sh`,
+  `update_did.sh`, `upload_p12.sh`) and config in `deployments/`
+- Postman collections (`postman-collections/`) for exercising the deployed
+  APIs (registry, eSignet OIDC client management)
+
+## Build & Test Commands
+
+There is no automated test suite here — validation is done by planning and
+applying Terraform, then exercising the deployed services with the Postman
+collection. Run these from `azure/terraform-scripts/<stage>/`:
+
+```bash
+# One-time: Terraform state storage
+cd terraform-scripts/storage-state
+terraform init
+terraform plan -var="subscription_id=your-subscription-id"
+terraform apply -var="subscription_id=your-subscription-id"
+```
+
+```bash
+# Core infra: AKS, network, bastion, Postgres
+cd terraform-scripts/infra
+terraform init
+terraform plan -var="subscription_id=your-subscription-id" -var="bastion_admin_password=your-password" -var="ssh_public_key=your-ssh-public-key"
+terraform apply -var="subscription_id=your-subscription-id" -var="bastion_admin_password=your-password" -var="ssh_public_key=your-ssh-public-key"
+```
+
+Tear-down (destructive — see caution below):
+
+```bash
+cd terraform-scripts/infra
+terraform destroy
+```
+
+After infra is up, service deployment is done from the bastion host by
+running `inji_deploy.sh` (fetched from a script hosting location documented
+in `README.md`) — read `README.md`'s "INJI service deployment" section
+before running it, since it expects the bastion/AKS context to already be
+configured via `az aks get-credentials`.
+
+## Configuration
+
+- `deployments/configs/.esignet.env`, `.inji.env`, `.registry.env` pin the
+  Helm chart/image versions for each service group; edit these to change
+  deployed versions.
+- `deployments/properties/*.properties` (`esignet.properties`,
+  `certify.properties`, `mimoto-default.properties`) hold application
+  config applied during service setup — the README's step-by-step guide
+  edits these when wiring up DID/credential-schema IDs.
+- Terraform variables are passed on the command line via `-var=...` flags
+  (see Build & Test Commands above) rather than a checked-in `.tfvars`
+  file — there is no `terraform.tfvars` in this folder.
+
+## Project Structure Notes
+
+```text
+azure/
+├── terraform-scripts/
+│   ├── storage-state/   - Terraform backend/state bucket setup
+│   └── infra/            - AKS, network, bastion, Postgres, identity modules
+├── deployments/
+│   ├── configs/           - Helm values + env files per service group
+│   ├── properties/        - application .properties + issuer config
+│   ├── schemas/           - sample credential schemas (Hospital, Vaccination)
+│   └── templates/         - credential HTML template
+├── postman-collections/   - API collections for registry/eSignet/DID setup
+├── assets/                - architecture diagrams
+├── inji_deploy.sh, update_did.sh, upload_p12.sh   - bastion-side service setup scripts
+└── LICENSE                - Mozilla Public License 2.0 (Terraform-module-scoped)
+```
+
+## Development Workflow
+
+1. Terraform changes: `terraform init` then `terraform plan` in the
+   relevant `terraform-scripts/<stage>/` folder before ever running
+   `apply`.
+2. Review `main.tf`/`variables.tf` in the specific module under
+   `terraform-scripts/infra/modules/` (`aks`, `bastion`, `identity`,
+   `network`, `psql`) you're changing — each is self-contained with its
+   own `outputs.tf`.
+3. Shell-script changes (`inji_deploy.sh`, `update_did.sh`,
+   `upload_p12.sh`): these are meant to run on the bastion host with `az`
+   and `kubectl` already configured — read the script's `get_input`/prompt
+   flow before changing it, since later steps depend on earlier prompts.
+4. Config edits under `deployments/configs` or `deployments/properties`
+   take effect only after the corresponding Helm release or config-update
+   step is re-run — check `README.md`'s step-by-step guide for which step
+   applies.
+
+## Pull Request Guidelines
+
+- State whether the change is to Terraform infra, a deployment script, or
+  Helm values/properties config.
+- If a Terraform change affects an existing resource's identity (name,
+  location, SKU) rather than just adding a new one, call this out — it
+  may force a destroy/recreate.
+- Do not include a real Azure subscription ID, bastion password, SSH key,
+  or Postgres credential in the PR description.
+
+## Repository-Specific Considerations
+
+- **`terraform apply` and `terraform destroy` under `terraform-scripts/`
+  provision and delete real Azure resources** (AKS cluster, VMs, Postgres,
+  networking). Never run these without the user's explicit request, and
+  confirm the target subscription first. The README also documents
+  deleting resource groups directly (`az group delete -y -n inji-rg-dev`)
+  as an alternative teardown — treat that the same way: destructive,
+  explicit-request-only.
+- `deployments/configs/*.env` and `deployments/properties/*.properties`
+  checked into `develop` contain demo/example values (test domains, demo
+  chart versions) — do not assume they're safe to deploy as-is to a real
+  environment, and don't replace them with real secrets in a commit.
+- The bastion-host scripts (`inji_deploy.sh`, `update_did.sh`,
+  `upload_p12.sh`) are fetched by URL from an external GitHub location
+  referenced in `README.md`, not run directly from this checkout — if you
+  change these scripts, note in the PR that the hosted copy also needs
+  updating.
+
+## Agent rules
+
+### Do
+
+1. Run `terraform init` and `terraform plan` before ever suggesting
+   `terraform apply` for a change under `terraform-scripts/`.
+2. Read the specific Terraform module (`modules/aks`, `modules/bastion`,
+   etc.) fully before editing its variables or resources.
+3. Flag any Terraform change that could force resource replacement
+   (name/location/SKU changes).
+4. Note in the PR if a bastion-host script change also needs to be applied
+   to the externally hosted copy referenced in `README.md`.
+
+### Do not
+
+1. Do not run `terraform apply`, `terraform destroy`, or `az group delete`
+   unless the user has explicitly asked to provision or tear down Azure
+   infrastructure.
+2. Do not put a real Azure subscription ID, bastion admin password, SSH
+   key, or database credential into a `.tfvars`/`.env` file, commit, or PR
+   description.
+3. Do not treat the demo values in `deployments/configs/*.env` as
+   production-ready without the user confirming they should be replaced.

--- a/azure/AGENTS.md
+++ b/azure/AGENTS.md
@@ -26,9 +26,12 @@ has two stages, per `azure/README.md`:
 
 ## Build & Test Commands
 
-There is no automated test suite here — validation is done by planning and
-applying Terraform, then exercising the deployed services with the Postman
-collection. Run these from `azure/terraform-scripts/<stage>/`:
+There is no automated test suite here. `terraform validate` and
+`terraform plan` are safe, read-only validation steps. `terraform apply`
+changes real cloud resources and requires explicit user approval before
+running — it is not a routine validation step. Once applied, exercise the
+deployed services with the Postman collection. Run these from
+`azure/terraform-scripts/<stage>/`:
 
 ```bash
 # One-time: Terraform state storage
@@ -42,8 +45,12 @@ terraform apply -var="subscription_id=your-subscription-id"
 # Core infra: AKS, network, bastion, Postgres
 cd terraform-scripts/infra
 terraform init
-terraform plan -var="subscription_id=your-subscription-id" -var="bastion_admin_password=your-password" -var="ssh_public_key=your-ssh-public-key"
-terraform apply -var="subscription_id=your-subscription-id" -var="bastion_admin_password=your-password" -var="ssh_public_key=your-ssh-public-key"
+export TF_VAR_subscription_id="your-subscription-id"
+export TF_VAR_bastion_admin_password="<load from a secret manager, never a literal>"
+export TF_VAR_ssh_public_key="your-ssh-public-key"
+terraform plan
+# terraform apply changes real cloud resources — only run after explicit user approval:
+terraform apply
 ```
 
 Tear-down (destructive — see caution below):
@@ -68,9 +75,14 @@ configured via `az aks get-credentials`.
   `certify.properties`, `mimoto-default.properties`) hold application
   config applied during service setup — the README's step-by-step guide
   edits these when wiring up DID/credential-schema IDs.
-- Terraform variables are passed on the command line via `-var=...` flags
-  (see Build & Test Commands above) rather than a checked-in `.tfvars`
-  file — there is no `terraform.tfvars` in this folder.
+- Terraform variables are passed on the command line, either via
+  `-var=...` flags or `TF_VAR_*` environment variables (see Build & Test
+  Commands above), rather than a checked-in `.tfvars` file — there is no
+  `terraform.tfvars` in this folder. Use `-var=...` only for non-sensitive
+  values; pass sensitive values like `bastion_admin_password` via
+  `TF_VAR_*` or an approved secret manager, never as a literal `-var=...`
+  argument (it would be exposed via shell history, process listings, and
+  CI logs).
 
 ## Project Structure Notes
 

--- a/gcp/AGENTS.md
+++ b/gcp/AGENTS.md
@@ -1,0 +1,176 @@
+# AGENTS.md
+
+Scope: this file covers the `gcp/` folder only. See the [root
+AGENTS.md](../AGENTS.md) for how this folder relates to `aws/` and
+`azure/`.
+
+## Repository Overview
+
+One-click deployment of the INJI stack (inji-certify, mimoto, inji-web,
+inji-verify) plus eSignet and Sunbird RC (registry) onto GCP. Deployment
+has three parts, per `gcp/README.md`:
+
+- **Terraform** provisions infrastructure (GKE cluster, network, Cloud SQL,
+  service accounts) in stages: `pre-config` then app-level infra.
+- **Cloud Build YAML** files under `builds/` wrap the Terraform/Helm steps
+  so they can be run as one `gcloud builds submit` command instead of
+  invoking Terraform/Helm by hand.
+- **Helm** deploys the application services onto the provisioned GKE
+  cluster, using config under `deployments/`.
+
+## Technology Stack
+
+- Terraform for GCP (google provider; only a `pre-config` stage exists
+  under `terraform-scripts/` on `develop` — see Project Structure Notes)
+- Google Cloud Build (`builds/*/deploy-script.yaml`,
+  `destroy-script.yaml`) as the orchestration layer
+- Helm charts, driven through Cloud Build and config in `deployments/`
+- Postman collections (`postman-collections/`) for exercising deployed
+  APIs
+
+## Build & Test Commands
+
+There is no automated test suite — validation is done by running Cloud
+Build submissions and then exercising the deployed services with the
+Postman collection. All commands below are documented in `gcp/README.md`
+and expect `PROJECT_ID`, `REGION`, `GSA` (service account), and related
+shell variables to already be set (see that README's "Setup CLI
+environment variables" section).
+
+```bash
+# One-time: Terraform state bucket
+gcloud storage buckets create gs://$PROJECT_ID-inji-state \
+  --project=$PROJECT_ID --default-storage-class=STANDARD \
+  --location=$REGION --uniform-bucket-level-access
+```
+
+```bash
+# Provision infra (GKE, network, Cloud SQL, etc.)
+gcloud builds submit --config="./builds/infra/deploy-script.yaml" \
+  --project=$PROJECT_ID \
+  --substitutions=_PROJECT_ID_=$PROJECT_ID,_SERVICE_ACCOUNT_=$SERVICE_ACCOUNT,_LOG_BUCKET_=$PROJECT_ID-inji-state
+```
+
+```bash
+# Deploy application services (Helm charts)
+gcloud builds submit --config="./builds/apps/deploy-script.yaml" \
+  --region=$REGION --project=$PROJECT_ID \
+  --substitutions=_PROJECT_ID_=$PROJECT_ID,_REGION_=$REGION,_LOG_BUCKET_=$PROJECT_ID-inji-state,_EMAIL_ID_=$EMAIL_ID,_DOMAIN_=$DOMAIN,_SERVICE_ACCOUNT_=$GSA,_FR_DOMAIN_=$FR_DOMAIN,_ESIGNET_DOMAIN_=$ESIGNET_DOMAIN,_VERIFY_DOMAIN_=$VERIFY_DOMAIN,_WEB_DID_BASE_URL_=$WEB_DID_BASE_URL
+```
+
+Teardown (destructive — see caution below) uses the matching
+`destroy-script.yaml` under `builds/infra/` and `builds/apps/` with the
+same substitution pattern.
+
+## Configuration
+
+- `gcp/.env` pins Helm chart/image versions for inji-certify, mimoto,
+  inji-web, inji-verify.
+- `deployments/.esignet.env` and `deployments/.registry.env` pin chart
+  versions for the eSignet and registry (Sunbird RC) service groups.
+- `terraform-variables/dev/pre-config/pre-config.tfvars` supplies the
+  actual values (project/network/firewall/GKE cluster/Cloud SQL shape)
+  consumed by `terraform-scripts/pre-config/variables.tf` — this file is
+  checked into `develop` with demo naming (`inji-demo-*`); review every
+  value before applying against a real project rather than assuming it's
+  ready to use as-is.
+- `deployments/secrets/key.jwk` is referenced by the p12-import build step
+  (`builds/p12-import/deploy-script.yaml`) as the expected location for the
+  OIDC client's private key JWK. **The copy checked into `develop` is a
+  real-shaped RSA private key, not a placeholder marker** — treat any file
+  at this path as sensitive, never let a real production key end up
+  committed here, and flag this file if you're asked to review the repo's
+  handling of secrets.
+
+## Project Structure Notes
+
+```text
+gcp/
+├── terraform-scripts/
+│   └── pre-config/        - backend.tf, pre-config.tf, variables.tf (landing-zone infra)
+├── terraform-variables/
+│   └── dev/pre-config/pre-config.tfvars   - actual values for the pre-config stage
+├── builds/
+│   ├── infra/              - Cloud Build wrapper: provision/destroy infra
+│   ├── apps/                - Cloud Build wrapper: deploy/destroy app services
+│   ├── config-update/       - Cloud Build wrapper: push properties/config changes
+│   └── p12-import/          - Cloud Build wrapper: mount OIDC p12 keystore to mimoto
+├── deployments/
+│   ├── configs/, properties/, secrets/  - Helm values, .properties, and key material
+├── postman-collections/    - API collections for registry/eSignet/DID setup
+└── assets/                  - architecture diagrams
+```
+
+Note: the README's "Workspace - Folder structure" section also describes a
+`builds/infra` step as doing "end to end Infrastructure deployment" and a
+separate `terraform-scripts` folder for "end to end Infrastructure" — in
+the actual `develop` tree, `terraform-scripts/` currently contains only the
+`pre-config` stage; the Cloud Build YAML in `builds/infra/` is the layer
+that actually drives it end to end. Confirm against the live tree before
+assuming other stages exist.
+
+## Development Workflow
+
+1. Terraform changes: work through `terraform-scripts/pre-config/*.tf` and
+   its matching entries in `terraform-variables/dev/pre-config/pre-config.tfvars`
+   together — the tfvars file's keys must match `variables.tf`.
+2. Cloud Build YAML changes (`builds/*/deploy-script.yaml`): these are
+   thin wrappers that invoke Terraform/Helm/kubectl steps with
+   `${_SUBSTITUTION}` variables — check every substitution used in the
+   step is also passed on the `gcloud builds submit` command line in
+   `README.md`, and update the README if you add or rename one.
+3. Config edits under `deployments/configs` or `deployments/properties`
+   are applied via the `config-update` Cloud Build step, not just by
+   editing the file — re-run that step after changing a properties file.
+
+## Pull Request Guidelines
+
+- State whether the change is to Terraform, a Cloud Build YAML wrapper, or
+  Helm values/properties config.
+- If a Terraform or `pre-config.tfvars` change alters an existing
+  resource's identity (name, region, machine type, network CIDR), call
+  this out — it may force a destroy/recreate of a live resource.
+- Do not include a real GCP project ID, service account email, or key
+  material in the PR description.
+
+## Repository-Specific Considerations
+
+- **The `deploy-script.yaml`/`destroy-script.yaml` Cloud Build steps under
+  `builds/infra/` and `builds/apps/` provision and delete real GCP
+  resources** (GKE cluster, Cloud SQL, networking, service accounts).
+  Never run a `gcloud builds submit ... destroy-script.yaml` or
+  `deploy-script.yaml` command without the user's explicit request, and
+  confirm the target `$PROJECT_ID` first.
+- `deployments/secrets/key.jwk` is tracked in git with real-shaped RSA key
+  material (see Configuration above) — this is an existing condition of
+  the repository, not something to silently "fix" as a drive-by change;
+  raise it explicitly if asked to review secret handling, and never add a
+  second real key alongside it.
+- `terraform-variables/dev/pre-config/pre-config.tfvars` uses permissive
+  demo firewall rules (SSH and HTTP/S open to `0.0.0.0/0`) — do not treat
+  this as a secure default to replicate elsewhere without the user
+  confirming that's intended.
+
+## Agent rules
+
+### Do
+
+1. Keep `pre-config.tfvars` keys in sync with `variables.tf` when editing
+   either.
+2. Check that every `${_SUBSTITUTION}` used in a Cloud Build YAML step is
+   documented in `README.md`'s `gcloud builds submit` example.
+3. Flag Terraform/tfvars changes that could force replacement of a live
+   resource.
+4. Call out `deployments/secrets/key.jwk` explicitly if asked to review or
+   report on secret handling in this folder.
+
+### Do not
+
+1. Do not run any `gcloud builds submit --config=./builds/.../deploy-script.yaml`
+   or `.../destroy-script.yaml` command unless the user has explicitly
+   asked to provision or tear down GCP infrastructure.
+2. Do not put a real GCP project ID, service account email, or private key
+   into a `.tfvars`/`.env` file, commit, or PR description.
+3. Do not copy the open (`0.0.0.0/0`) firewall rules from
+   `pre-config.tfvars` into a new environment without the user confirming
+   that's intended.

--- a/gcp/AGENTS.md
+++ b/gcp/AGENTS.md
@@ -175,9 +175,10 @@ assuming other stages exist.
    `destroy-script.yaml` command (e.g. under `builds/infra/`) unless the
    user has explicitly asked to provision or tear down GCP
    infrastructure, and has confirmed the target project.
-2. Do not run an application `deploy-script.yaml` command (e.g. under
-   `builds/apps/`) unless the user has explicitly asked to deploy
-   application services, and has confirmed the target project.
+2. Do not run an application `deploy-script.yaml` or `destroy-script.yaml`
+   command (e.g. under `builds/apps/`) unless the user has explicitly
+   asked to deploy or tear down application services, and has confirmed
+   the target project.
 3. Do not put a real GCP project ID, service account email, or private key
    into a `.tfvars`/`.env` file, commit, or PR description.
 4. Do not copy the open (`0.0.0.0/0`) firewall rules from

--- a/gcp/AGENTS.md
+++ b/gcp/AGENTS.md
@@ -10,8 +10,10 @@ One-click deployment of the INJI stack (inji-certify, mimoto, inji-web,
 inji-verify) plus eSignet and Sunbird RC (registry) onto GCP. Deployment
 has three parts, per `gcp/README.md`:
 
-- **Terraform** provisions infrastructure (GKE cluster, network, Cloud SQL,
-  service accounts) in stages: `pre-config` then app-level infra.
+- **Terraform** provisions the GKE/network/Cloud SQL/service-account
+  infrastructure from `terraform-scripts/pre-config/` — this is the only
+  stage under `terraform-scripts/`, there is no separate app-level
+  Terraform stage. `builds/infra/` invokes this same Terraform state.
 - **Cloud Build YAML** files under `builds/` wrap the Terraform/Helm steps
   so they can be run as one `gcloud builds submit` command instead of
   invoking Terraform/Helm by hand.
@@ -30,12 +32,15 @@ has three parts, per `gcp/README.md`:
 
 ## Build & Test Commands
 
-There is no automated test suite — validation is done by running Cloud
-Build submissions and then exercising the deployed services with the
-Postman collection. All commands below are documented in `gcp/README.md`
-and expect `PROJECT_ID`, `REGION`, `GSA` (service account), and related
-shell variables to already be set (see that README's "Setup CLI
-environment variables" section).
+There is no automated test suite. Terraform and configuration checks
+(e.g. `terraform validate`/`plan`, reviewing a `.tfvars`/Cloud Build YAML
+diff) are safe validation steps. Cloud Build submissions that provision
+or deploy resources change real infrastructure and require explicit
+user authorization before running — they are not routine validation.
+Once deployed, exercise the services with the Postman collection. All
+commands below are documented in `gcp/README.md` and expect `PROJECT_ID`,
+`REGION`, `GSA` (service account), and related shell variables to already
+be set (see that README's "Setup CLI environment variables" section).
 
 ```bash
 # One-time: Terraform state bucket
@@ -166,11 +171,15 @@ assuming other stages exist.
 
 ### Do not
 
-1. Do not run any `gcloud builds submit --config=./builds/.../deploy-script.yaml`
-   or `.../destroy-script.yaml` command unless the user has explicitly
-   asked to provision or tear down GCP infrastructure.
-2. Do not put a real GCP project ID, service account email, or private key
+1. Do not run an infrastructure `deploy-script.yaml` or
+   `destroy-script.yaml` command (e.g. under `builds/infra/`) unless the
+   user has explicitly asked to provision or tear down GCP
+   infrastructure, and has confirmed the target project.
+2. Do not run an application `deploy-script.yaml` command (e.g. under
+   `builds/apps/`) unless the user has explicitly asked to deploy
+   application services, and has confirmed the target project.
+3. Do not put a real GCP project ID, service account email, or private key
    into a `.tfvars`/`.env` file, commit, or PR description.
-3. Do not copy the open (`0.0.0.0/0`) firewall rules from
+4. Do not copy the open (`0.0.0.0/0`) firewall rules from
    `pre-config.tfvars` into a new environment without the user confirming
    that's intended.


### PR DESCRIPTION
Addresses https://github.com/mosip/mosip-config/issues/10670 — adds a root AGENTS.md hub plus per-cloud guides (aws/AGENTS.md, azure/AGENTS.md, gcp/AGENTS.md), since this repo has three independent deployment projects (AWS CDK, Azure Terraform, GCP Terraform + Cloud Build) sharing no tooling or code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added repository-wide guidance covering AWS, Azure, and GCP deployment projects.
  * Documented supported technologies, project structures, configuration locations, workflows, validation commands, and pull-request requirements.
  * Added infrastructure safety guidance, including safeguards for destructive operations and restrictions on provisioning.
  * Clarified secret-handling practices, credential protection, vendored content, and environment-specific deployment considerations.
  * Added cloud-specific guidance for CDK, Terraform, Helm, Cloud Build, and service deployment workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->